### PR TITLE
fix: Add timeout to client ping on creation

### DIFF
--- a/DockerTools/Exceptions/DockerUnreachableException.cs
+++ b/DockerTools/Exceptions/DockerUnreachableException.cs
@@ -6,4 +6,8 @@ public class DockerUnreachableException : Exception
         : base("An error has occurred while attempting to connect to the Docker instance. See the inner exception for details.", inner)
     {
     }
+
+    public DockerUnreachableException(string message) : base(message)
+    {
+    }
 }


### PR DESCRIPTION
### What changes does this PR introduce (please leave the links to the tickets)? Are they tested?
* N/A


### Are you introducing a breaking change for a consumer? Are you reporting those changes on a ticket or coordinating both PRs?
* No.


### What dependencies does this PR have (DB changes, AWS Secrets, downstream APIs, ...)? What are the PRs and/or JIRA tickets for those?
* None.


### Are kenbi dependencies up-to-date (Kenbi.* nuget packages)?
* N/A

