### PR TITLE
fix: Revert Docker.Dotnet library and codes changes on container removal

### DIFF
--- a/DockerTools/Containers/ContainerSetup.cs
+++ b/DockerTools/Containers/ContainerSetup.cs
@@ -5,7 +5,6 @@ using Kenbi.DockerTools.Utils;
 
 namespace Kenbi.DockerTools.Containers;
 
-
 /// <inheritdoc />
 public class ContainerSetup<T> : IContainerSetup<T> where T : class, IContainer
 {
@@ -42,6 +41,11 @@ public class ContainerSetup<T> : IContainerSetup<T> where T : class, IContainer
                 Timeout = this.Container.HealthCheck.Timeout,
                 Retries = this.Container.HealthCheck.Retries,
                 StartPeriod = this.Container.HealthCheck.StartPeriod
+            },
+            Labels = new Dictionary<string, string>
+            {
+                { "DockerTools", "true" },
+                { "DockerTools.ExecutionInstance", _client.InstanceId.ToString("N") }
             }
         };
 
@@ -100,6 +104,11 @@ public class ContainerSetup<T, TParameters> : IContainerSetup<T, TParameters> wh
                 Timeout = this.Container.HealthCheck.Timeout,
                 Retries = this.Container.HealthCheck.Retries,
                 StartPeriod = this.Container.HealthCheck.StartPeriod
+            },
+            Labels = new Dictionary<string, string>
+            {
+                { "DockerTools", "true" },
+                { "DockerTools.ExecutionInstance", _client.InstanceId.ToString("N") }
             }
         };
 

--- a/DockerTools/DockerTools.csproj
+++ b/DockerTools/DockerTools.csproj
@@ -19,7 +19,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Docker.DotNet" Version="3.125.15" />
+      <PackageReference Include="Docker.DotNet" Version="3.125.12" />
     </ItemGroup>
 
 </Project>

--- a/DockerTools/DockerToolsClient.cs
+++ b/DockerTools/DockerToolsClient.cs
@@ -11,6 +11,7 @@ namespace Kenbi.DockerTools;
 public class DockerToolsClient : IAsyncDisposable
 {
     internal readonly DockerClient Client;
+    internal readonly Guid InstanceId;
 
     /// <summary>
     /// List of all configured containers.
@@ -20,11 +21,13 @@ public class DockerToolsClient : IAsyncDisposable
     internal DockerToolsClient()
     {
         this.Client = new DockerClientConfiguration().CreateClient();
+        this.InstanceId = Guid.NewGuid();
     }
 
     internal DockerToolsClient(Uri uri)
     {
         this.Client = new DockerClientConfiguration(uri).CreateClient();
+        this.InstanceId = Guid.NewGuid();
     }
 
     /// <summary>

--- a/DockerTools/Extensions/DockerToolsClientExtensions.cs
+++ b/DockerTools/Extensions/DockerToolsClientExtensions.cs
@@ -13,7 +13,7 @@ namespace Kenbi.DockerTools.Extensions;
 public static class DockerToolsClientExtensions
 {
     private const string HealthCheckHealthy = "healthy";
-    private const int HealthCheckAttempts = 5;
+    private const int HealthCheckAttempts = 10;
 
     /// <summary>
     /// Creates all configured containers.
@@ -150,21 +150,13 @@ public static class DockerToolsClientExtensions
 
             report = await StopAsync(dc, container, token);
 
-            if (report != null)
+            if (report.Status != OperationStatus.Success)
             {
                 result.Add(report);
                 continue;
             }
 
             report = await RemoveAsync(dc, container, token);
-
-            if (report != null)
-            {
-                result.Add(report);
-                continue;
-            }
-
-            report = new StopAndRemoveReport(container.Configuration.Name, container.Id, OperationStatus.Success);
 
             result.Add(report);
         }

--- a/DockerTools/Extensions/DockerToolsClientInitializationExtensions.cs
+++ b/DockerTools/Extensions/DockerToolsClientInitializationExtensions.cs
@@ -7,9 +7,9 @@ internal static class DockerToolsClientInitializationExtensions
     private const string ApiUri = "http://localhost:2375";
     private const int Timeout = 30000;
 
-    internal static bool TryGetUriByEnvironment(out Uri uri)
+    internal static bool TryGetUriByEnvironment(out Uri? uri)
     {
-        HttpClient client = null;
+        HttpClient? client = null;
 
         try
         {


### PR DESCRIPTION
### What changes does this PR introduce (please leave the links to the tickets)? Are they tested?
* N/A


### Are you introducing a breaking change for a consumer? Are you reporting those changes on a ticket or coordinating both PRs?
* No.


### What dependencies does this PR have (DB changes, AWS Secrets, downstream APIs, ...)? What are the PRs and/or JIRA tickets for those?
* None.


### Are kenbi dependencies up-to-date (Kenbi.* nuget packages)?
* N/A

